### PR TITLE
Remove universal wheel setting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Python 2 is not supported, so this setting is not correct. It is not required for packaging.