### PR TITLE
Special chars

### DIFF
--- a/girder_item_tags/__init__.py
+++ b/girder_item_tags/__init__.py
@@ -44,7 +44,7 @@ def _validate_item_tag_list(tags):
 
 def search_handler(query, types, user=None, level=None, limit=0, offset=0):
     # Break the query into a list of keywords separated by whitespace
-    query = re.compile(r'\W+').split(query.strip())
+    query = re.compile(r'\s+').split(query.strip())
     # Find all items that are tagged with every string in the query
     cursor = Item()\
         .find({'meta.girder_item_tags': {'$all': query}})\

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name='girder-item-tags',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/girder',
-    version='0.2.0',
+    version='0.3.0',
     zip_safe=False,
     entry_points={
         'girder.plugin': [

--- a/tests/test_item_tag_search.py
+++ b/tests/test_item_tag_search.py
@@ -93,3 +93,23 @@ def test_search_multiple_search_tags(server, user, userFolder):
     print(results)
     assert len(results) == 1
     assert results[0]['_id'] == str(item2['_id'])
+
+
+@pytest.mark.plugin('item_tags')
+def test_search_special_characters(server, user, userFolder):
+    item = createItem('testItem', user, userFolder, ['colon:', 'semicolon;', 'tilde~', 'dash-'])
+    resp = server.request(
+        path='/resource/search',
+        method='GET',
+        user=user,
+        params={
+            'q': 'colon: semicolon; tilde~ dash-',
+            'mode': 'item_tags',
+            'types': '["item"]'
+        }
+    )
+    assertStatusOk(resp)
+    results = resp.json['item']
+    print(results)
+    assert len(results) == 1
+    assert results[0]['_id'] == str(item['_id'])


### PR DESCRIPTION
Search queries were being split on the regex `\W`, which matches an non-alphanumeric character. Searches like `NLI:DOCUMENTATION` were being split on the colon into the tags `NLI` and `DOCUMENTATION`.

Fixes #5 